### PR TITLE
Fix things for Parallel Access and add support for ISUPPORT

### DIFF
--- a/examples/nicktrack/nicktrack.go
+++ b/examples/nicktrack/nicktrack.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/thoja/go-ircevent"
 	"sort"
 	"time"
@@ -10,6 +11,7 @@ import (
 const channel = "#ggnet"
 const serverssl = "irc.homelien.no:6667"
 
+// also check Feature Detection (because NickTrack needs it anyway)
 func main() {
 	ircnick1 := "blatibalt1"
 	irccon := irc.IRC(ircnick1, "blatiblat")
@@ -39,6 +41,11 @@ func main() {
 				}
 				fmt.Printf("\n")
 			}
+
+			fmt.Println()
+			spew.Dump(irccon.Features)
+			fmt.Println()
+			spew.Dump(irccon.KnownFeatures)
 		}
 	}()
 	irccon.Loop()

--- a/examples/nicktrack/nicktrack.go
+++ b/examples/nicktrack/nicktrack.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/thoja/go-ircevent"
 	"sort"
 	"time"
@@ -30,22 +29,42 @@ func main() {
 		for {
 			<-t.C
 			var keys []string
-			if _, ok := irccon.Channels[channel]; ok == true {
-				for k, _ := range irccon.Channels[channel].Users {
-					keys = append(keys, k)
-				}
+			if ch, ok := irccon.GetChannel(channel); ok {
+				ch.IterUsers(func(name string, user irc.User) {
+					keys = append(keys, name)
+				})
+
 				sort.Strings(keys)
-				fmt.Printf("%d: ", len(keys))
-				for _, k := range keys {
-					fmt.Printf("(%s)%s ", irccon.Channels[channel].Users[k].Mode, k)
+
+				for _, user := range keys {
+					u, _ := ch.GetUser(user)
+					fmt.Printf("(%s)%s ", u.Mode, user)
 				}
-				fmt.Printf("\n")
+				fmt.Println()
 			}
 
 			fmt.Println()
-			spew.Dump(irccon.Features)
+
+			fmt.Println("Features:")
+			irccon.IterFeatures(func(name string, feature *irc.Feature) {
+				fmt.Printf("  %s = %s\n", name, feature.Value)
+			})
+
 			fmt.Println()
-			spew.Dump(irccon.KnownFeatures)
+			fmt.Println("Known Features: ")
+			prefix := irccon.PrefixModes()
+			nickLength := irccon.NickLength()
+			fmt.Printf("  NICKLEN: %d\n\n", nickLength)
+			pmodes := ""
+			dmodes := ""
+			for mode, _ := range prefix.Modes {
+				pmodes += string(mode)
+			}
+			for mode, _ := range prefix.Display {
+				dmodes += string(mode)
+			}
+			fmt.Printf("  Prefix Modes: %s\n", pmodes)
+			fmt.Printf("  Display Modes: %s\n\n", dmodes)
 		}
 	}()
 	irccon.Loop()

--- a/irc.go
+++ b/irc.go
@@ -591,18 +591,20 @@ func IRC(nick, user string) *Connection {
 	}
 
 	irc := &Connection{
-		nick:        nick,
-		nickcurrent: nick,
-		user:        user,
-		Log:         log.New(os.Stdout, "", log.LstdFlags),
-		end:         make(chan struct{}),
-		Version:     VERSION,
-		KeepAlive:   4 * time.Minute,
-		Timeout:     1 * time.Minute,
-		PingFreq:    15 * time.Minute,
-		SASLMech:    "PLAIN",
-		QuitMessage: "",
-		Channels:    make(map[string]Channel),
+		nick:          nick,
+		nickcurrent:   nick,
+		user:          user,
+		Log:           log.New(os.Stdout, "", log.LstdFlags),
+		end:           make(chan struct{}),
+		Version:       VERSION,
+		KeepAlive:     4 * time.Minute,
+		Timeout:       1 * time.Minute,
+		PingFreq:      15 * time.Minute,
+		SASLMech:      "PLAIN",
+		QuitMessage:   "",
+		Channels:      make(map[string]Channel),
+		Features:      makeFeatures(),
+		KnownFeatures: makeKnownFeatures(),
 	}
 	irc.setupCallbacks()
 	return irc

--- a/irc.go
+++ b/irc.go
@@ -591,20 +591,19 @@ func IRC(nick, user string) *Connection {
 	}
 
 	irc := &Connection{
-		nick:          nick,
-		nickcurrent:   nick,
-		user:          user,
-		Log:           log.New(os.Stdout, "", log.LstdFlags),
-		end:           make(chan struct{}),
-		Version:       VERSION,
-		KeepAlive:     4 * time.Minute,
-		Timeout:       1 * time.Minute,
-		PingFreq:      15 * time.Minute,
-		SASLMech:      "PLAIN",
-		QuitMessage:   "",
-		Channels:      make(map[string]Channel),
-		Features:      makeFeatures(),
-		KnownFeatures: makeKnownFeatures(),
+		nick:        nick,
+		nickcurrent: nick,
+		user:        user,
+		Log:         log.New(os.Stdout, "", log.LstdFlags),
+		end:         make(chan struct{}),
+		Version:     VERSION,
+		KeepAlive:   4 * time.Minute,
+		Timeout:     1 * time.Minute,
+		PingFreq:    15 * time.Minute,
+		SASLMech:    "PLAIN",
+		QuitMessage: "",
+		Channels:    make(map[string]*Channel),
+		features:    newFeatures(),
 	}
 	irc.setupCallbacks()
 	return irc

--- a/irc_isupport.go
+++ b/irc_isupport.go
@@ -102,7 +102,20 @@ func (irc *Connection) SetupFeatureDetect() {
 			}
 			switch idx := strings.Index(arg, "="); idx {
 			case -1:
-				irc.Features.Params[arg] = true
+				if strings.HasPrefix(arg, "-") {
+					// we should check if its one of those that has defaults but in practice
+					// an IRC server isn't going to stop advertising one of those kinds of
+					// features
+
+					if _, ok := irc.Features.Params[arg[1:]]; ok {
+						delete(irc.Features.Params, arg[1:])
+					}
+					if _, ok := irc.Features.Options[arg[1:]]; ok {
+						delete(irc.Features.Options, arg[1:])
+					}
+				} else {
+					irc.Features.Params[arg] = true
+				}
 			default:
 				irc.Features.Options[arg[0:idx]] = arg[idx+1:]
 				if call, ok := knownFeaturesTypes[arg[0:idx]]; ok {

--- a/irc_isupport.go
+++ b/irc_isupport.go
@@ -1,0 +1,114 @@
+package irc
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Features exposes the supported features from RPL_ISUPPORT
+type Features struct {
+	Params  map[string]bool
+	Options map[string]string
+}
+
+// KnownFeatures exposes the features we parse out for utilization
+type KnownFeatures struct {
+	PrefixModes        map[rune]rune
+	PrefixModesDisplay map[rune]rune
+	NickLength         uint
+}
+
+func makeKnownFeatures() KnownFeatures {
+	return KnownFeatures{
+		PrefixModes:        make(map[rune]rune),
+		PrefixModesDisplay: make(map[rune]rune),
+		NickLength:         30,
+	}
+}
+
+func fillAssumptions(f *Features) {
+	optAssumptions := map[string]string{
+		"CHANTYPES": "#",
+		"PREFIX":    "(ov)@+",
+	}
+
+	for opt, val := range optAssumptions {
+		f.Options[opt] = val
+	}
+}
+
+func makeFeatures() *Features {
+	ret := Features{
+		Params:  make(map[string]bool),
+		Options: make(map[string]string),
+	}
+	fillAssumptions(&ret)
+
+	return &ret
+}
+
+func (irc *Connection) knownFeaturesPrefix() {
+	if pmodes, ok := irc.Features.Options["PREFIX"]; ok {
+		idx := make(map[int]rune)
+		split := -1
+		currIdx := 0
+		for _, char := range pmodes {
+			switch char {
+			case '(':
+				continue
+			case ')':
+				split = 0
+				currIdx = 0
+				continue
+			default:
+				if split == 0 {
+					irc.KnownFeatures.PrefixModes[idx[currIdx]] = char
+					currIdx++
+				} else {
+					idx[currIdx] = char
+					currIdx++
+				}
+			}
+		}
+
+		for ml, dl := range irc.KnownFeatures.PrefixModes {
+			irc.KnownFeatures.PrefixModesDisplay[dl] = ml
+		}
+	}
+}
+
+func (irc *Connection) knownFeaturesNickLength() {
+	if nlen, ok := irc.Features.Options["NICKLEN"]; ok {
+		if nl, err := strconv.ParseUint(nlen, 10, 64); err == nil {
+			irc.KnownFeatures.NickLength = uint(nl)
+		}
+	}
+}
+
+// SetupFeatureDetect allows for the connection to have FeatureDetection enabled on it
+func (irc *Connection) SetupFeatureDetect() {
+	irc.AddCallback("005", func(e *Event) {
+		knownFeaturesTypes := map[string]func(){
+			"PREFIX":  irc.knownFeaturesPrefix,
+			"NICKLEN": irc.knownFeaturesNickLength,
+		}
+
+		irc.featuresMutex.Lock()
+		defer irc.featuresMutex.Unlock()
+
+		for _, arg := range e.Arguments[1:] {
+			if strings.Index(arg, " ") != -1 {
+				return
+			}
+			switch idx := strings.Index(arg, "="); idx {
+			case -1:
+				irc.Features.Params[arg] = true
+			default:
+				irc.Features.Options[arg[0:idx]] = arg[idx+1:]
+				if call, ok := knownFeaturesTypes[arg[0:idx]]; ok {
+					call()
+				}
+			}
+		}
+	})
+}

--- a/irc_isupport.go
+++ b/irc_isupport.go
@@ -3,102 +3,18 @@ package irc
 import (
 	"strconv"
 	"strings"
+	"sync"
 )
-
-// Features exposes the supported features from RPL_ISUPPORT
-type Features struct {
-	Params  map[string]bool
-	Options map[string]string
-}
-
-// KnownFeatures exposes the features we parse out for utilization
-type KnownFeatures struct {
-	PrefixModes        map[rune]rune
-	PrefixModesDisplay map[rune]rune
-	NickLength         uint
-}
-
-func makeKnownFeatures() KnownFeatures {
-	return KnownFeatures{
-		PrefixModes:        make(map[rune]rune),
-		PrefixModesDisplay: make(map[rune]rune),
-		NickLength:         30,
-	}
-}
-
-func fillAssumptions(f *Features) {
-	optAssumptions := map[string]string{
-		"CHANTYPES": "#",
-		"PREFIX":    "(ov)@+",
-	}
-
-	for opt, val := range optAssumptions {
-		f.Options[opt] = val
-	}
-}
-
-func makeFeatures() *Features {
-	ret := Features{
-		Params:  make(map[string]bool),
-		Options: make(map[string]string),
-	}
-	fillAssumptions(&ret)
-
-	return &ret
-}
-
-func (irc *Connection) knownFeaturesPrefix() {
-	if pmodes, ok := irc.Features.Options["PREFIX"]; ok {
-		idx := make(map[int]rune)
-		split := -1
-		currIdx := 0
-		for _, char := range pmodes {
-			switch char {
-			case '(':
-				continue
-			case ')':
-				split = 0
-				currIdx = 0
-				continue
-			default:
-				if split == 0 {
-					irc.KnownFeatures.PrefixModes[idx[currIdx]] = char
-					currIdx++
-				} else {
-					idx[currIdx] = char
-					currIdx++
-				}
-			}
-		}
-
-		for ml, dl := range irc.KnownFeatures.PrefixModes {
-			irc.KnownFeatures.PrefixModesDisplay[dl] = ml
-		}
-	}
-}
-
-func (irc *Connection) knownFeaturesNickLength() {
-	if nlen, ok := irc.Features.Options["NICKLEN"]; ok {
-		if nl, err := strconv.ParseUint(nlen, 10, 64); err == nil {
-			irc.KnownFeatures.NickLength = uint(nl)
-		}
-	}
-}
 
 // SetupFeatureDetect allows for the connection to have FeatureDetection enabled on it
 func (irc *Connection) SetupFeatureDetect() {
 	irc.AddCallback("005", func(e *Event) {
-		knownFeaturesTypes := map[string]func(){
-			"PREFIX":  irc.knownFeaturesPrefix,
-			"NICKLEN": irc.knownFeaturesNickLength,
-		}
-
-		irc.featuresMutex.Lock()
-		defer irc.featuresMutex.Unlock()
+		irc.features.Lock()
+		defer irc.features.Unlock()
 
 		for _, arg := range e.Arguments[1:] {
 			if strings.Index(arg, " ") != -1 {
-				return
+				continue
 			}
 			switch idx := strings.Index(arg, "="); idx {
 			case -1:
@@ -106,22 +22,199 @@ func (irc *Connection) SetupFeatureDetect() {
 					// we should check if its one of those that has defaults but in practice
 					// an IRC server isn't going to stop advertising one of those kinds of
 					// features
-
-					if _, ok := irc.Features.Params[arg[1:]]; ok {
-						delete(irc.Features.Params, arg[1:])
-					}
-					if _, ok := irc.Features.Options[arg[1:]]; ok {
-						delete(irc.Features.Options, arg[1:])
-					}
+					irc.features.delFeature(arg[1:])
 				} else {
-					irc.Features.Params[arg] = true
+					irc.features.addFeature(arg, "")
 				}
 			default:
-				irc.Features.Options[arg[0:idx]] = arg[idx+1:]
-				if call, ok := knownFeaturesTypes[arg[0:idx]]; ok {
-					call()
-				}
+				irc.features.addFeature(arg[0:idx], arg[idx+1:])
 			}
 		}
 	})
+}
+
+// Feature is a single Feature as exposed by ISUPPORT
+type Feature struct {
+	sync.Mutex
+	Enabled bool
+	Value   string
+
+	parsedValue interface{}
+}
+
+// Features exposes the supported features from RPL_ISUPPORT
+type Features struct {
+	sync.Mutex
+	features  map[string]*Feature
+	callbacks map[string][]func(string, *Feature)
+}
+
+func newFeatures() *Features {
+	ret := &Features{
+		features:  make(map[string]*Feature),
+		callbacks: make(map[string][]func(string, *Feature)),
+	}
+
+	ret.fill()
+
+	return ret
+}
+
+// PrefixModes provides structured access to the PREFIX in ISUPPORT
+func (irc *Connection) PrefixModes() *PrefixModes {
+	if feat, ok := irc.GetFeature("PREFIX"); ok {
+		feat.Lock()
+		defer feat.Unlock()
+		ret, success := feat.parsedValue.(*PrefixModes)
+		if success {
+			return ret
+		}
+	}
+
+	return nil
+}
+
+// NickLength provides structured access to the NICKLEN in ISUPPORT
+func (irc *Connection) NickLength() uint {
+	if feat, ok := irc.GetFeature("NICKLEN"); ok {
+		feat.Lock()
+		defer feat.Unlock()
+		ret, success := feat.parsedValue.(uint)
+		if success {
+			return ret
+		}
+	}
+
+	return 0
+}
+
+// GetFeature returns an ISUPPORT feature by name, and a boolean indicating
+// if the value was present or not. One should be sure to lock/unlock the feature
+// when accessing or modifying it.
+func (irc *Connection) GetFeature(name string) (*Feature, bool) {
+	irc.features.Lock()
+	defer irc.features.Unlock()
+	feat, ok := irc.features.features[name]
+	return feat, ok
+}
+
+// IterFeatures allows for one to iterate over the features present and perform
+// actions with/upon it with the call function passed in. There is no need to lock
+// the feature, this handles locking for the caller.
+func (irc *Connection) IterFeatures(call func(string, *Feature)) {
+	irc.features.Lock()
+	defer irc.features.Unlock()
+	for name, feat := range irc.features.features {
+		feat.Lock()
+		call(name, feat)
+		feat.Unlock()
+	}
+}
+
+// Features private functions
+
+func (f *Features) addFeature(name string, val string) {
+	f.features[name] = &Feature{
+		Value:   val,
+		Enabled: true,
+	}
+	f.call(name)
+}
+
+func (f *Features) delFeature(name string) {
+	delete(f.features, name)
+}
+
+func (f *Features) fill() {
+	defaultCallbacks := map[string][]func(string, *Feature){
+		"PREFIX":  []func(string, *Feature){f.knownFeaturesPrefix},
+		"NICKLEN": []func(string, *Feature){f.knownFeaturesNickLength},
+		"EXCEPTS": []func(string, *Feature){f.exceptsEncountered}, // Value = e
+		"INVEX":   []func(string, *Feature){f.invexEncountered},   // Value = I
+		// INVEX, EXEMPT?
+	}
+
+	defaults := map[string]string{
+		"CHANTYPES": "#",
+		"PREFIX":    "(ov)@+",
+	}
+
+	f.Lock()
+	for feat, call := range defaultCallbacks {
+		f.callbacks[feat] = call
+	}
+
+	for feat, val := range defaults {
+		// using addFeature to make sure callbacks are called for defaults!
+		f.addFeature(feat, val)
+	}
+	f.Unlock()
+}
+
+func (f *Features) call(feature string) {
+	for _, call := range f.callbacks[feature] {
+		f.features[feature].Lock()
+		call(feature, f.features[feature])
+		f.features[feature].Unlock()
+	}
+}
+
+func (f *Features) exceptsEncountered(name string, feature *Feature) {
+	if feature.Value == "" {
+		feature.Value = "e"
+	}
+}
+
+func (f *Features) invexEncountered(name string, feature *Feature) {
+	if feature.Value == "" {
+		feature.Value = "I"
+	}
+}
+
+func (f *Features) knownFeaturesPrefix(name string, feature *Feature) {
+	idx := make(map[int]rune)
+	split, currIdx := -1, 0
+
+	pm := &PrefixModes{
+		Modes:   make(map[rune]rune),
+		Display: make(map[rune]rune),
+	}
+
+	for _, char := range feature.Value {
+		switch char {
+		case '(':
+			continue
+		case ')':
+			split = 0
+			currIdx = 0
+			continue
+		default:
+			if split == 0 {
+				pm.Modes[idx[currIdx]] = char
+				currIdx++
+			} else {
+				idx[currIdx] = char
+				currIdx++
+			}
+		}
+	}
+
+	for mode, display := range pm.Modes {
+		pm.Display[display] = mode
+	}
+
+	feature.parsedValue = pm
+}
+
+func (f *Features) knownFeaturesNickLength(name string, feature *Feature) {
+	if nlen, err := strconv.ParseUint(feature.Value, 10, 64); err == nil {
+		feature.parsedValue = uint(nlen)
+	}
+}
+
+// PrefixModes presents a forwards and backwards map of mode character
+// to display character
+type PrefixModes struct {
+	Modes   map[rune]rune
+	Display map[rune]rune
 }

--- a/irc_isupport.go
+++ b/irc_isupport.go
@@ -65,8 +65,7 @@ func (irc *Connection) PrefixModes() *PrefixModes {
 	if feat, ok := irc.GetFeature("PREFIX"); ok {
 		feat.Lock()
 		defer feat.Unlock()
-		ret, success := feat.parsedValue.(*PrefixModes)
-		if success {
+		if ret, ok := feat.parsedValue.(*PrefixModes); ok {
 			return ret
 		}
 	}
@@ -79,8 +78,7 @@ func (irc *Connection) NickLength() uint {
 	if feat, ok := irc.GetFeature("NICKLEN"); ok {
 		feat.Lock()
 		defer feat.Unlock()
-		ret, success := feat.parsedValue.(uint)
-		if success {
+		if ret, ok := feat.parsedValue.(uint); ok {
 			return ret
 		}
 	}
@@ -131,7 +129,6 @@ func (f *Features) fill() {
 		"NICKLEN": []func(string, *Feature){f.knownFeaturesNickLength},
 		"EXCEPTS": []func(string, *Feature){f.exceptsEncountered}, // Value = e
 		"INVEX":   []func(string, *Feature){f.invexEncountered},   // Value = I
-		// INVEX, EXEMPT?
 	}
 
 	defaults := map[string]string{

--- a/irc_nicktrack.go
+++ b/irc_nicktrack.go
@@ -2,25 +2,81 @@ package irc
 
 import (
 	"strings"
+	"sync"
 )
 
-//Struct to store Channel Info
+// Channel stores the channel information for a channel this Connection is a member of
 type Channel struct {
+	sync.Mutex
+	// We should extract topic by handling the correct Event at some point in the future!
 	Topic string
-	Mode  string
+	// We should extract channel modes by handling the correct Event at some point in the future!
+	Mode string
+	// leaving exposed for now, will be unexported in the future!
 	Users map[string]User
 }
 
+func (ch *Channel) GetUser(name string) (User, bool) {
+	ch.Lock()
+	defer ch.Unlock()
+	ret, ok := ch.Users[name]
+	return ret, ok
+}
+
+func (ch *Channel) IterUsers(call func(string, User)) {
+	ch.Lock()
+	defer ch.Unlock()
+	for name, user := range ch.Users {
+		call(name, user)
+	}
+}
+
+// User stores information on an IRC user encountered by this Connection
 type User struct {
+	// FIXME: If we support Host we should set up a WHO handler
+	// Careful though - some IRCd's (looking at unreal) silently treat WHO as WHOX
+	// and the resultant fields we expect to parse out could be out of order!
 	Host string
 	Mode string
 }
 
+// This checks by display mode, not by the mode sent in MODE commands (since those are valid
+// letters for general usage in things MODE would apply upon)
 func (irc *Connection) isModeChar(c rune) bool {
-	_, ok := irc.KnownFeatures.PrefixModesDisplay[c]
+	_, ok := irc.PrefixModes().Display[c]
 	return ok
 }
 
+func (irc *Connection) getOrCreateChannel(name string) *Channel {
+	irc.channelsMutex.Lock()
+	defer irc.channelsMutex.Unlock()
+	if _, ok := irc.Channels[name]; !ok {
+		irc.Channels[name] = &Channel{Users: make(map[string]User)}
+	}
+	return irc.Channels[name]
+}
+
+// GetChannel gets a channel by name that the Connection is on
+func (irc *Connection) GetChannel(name string) (*Channel, bool) {
+	irc.channelsMutex.Lock()
+	defer irc.channelsMutex.Unlock()
+	ret, ok := irc.Channels[name]
+	return ret, ok
+}
+
+// IterChannels allows for calling code to provide a callable that is ran for each
+// channel the Connection is on
+func (irc *Connection) IterChannels(call func(string, *Channel)) {
+	irc.channelsMutex.Lock()
+	defer irc.channelsMutex.Unlock()
+	for name, ch := range irc.Channels {
+		ch.Lock()
+		call(name, ch)
+		ch.Unlock()
+	}
+}
+
+// SetupNickTrack enables stateful tracking of IRC Users and Channels on this Connection
 func (irc *Connection) SetupNickTrack() {
 	// relies on ISUPPORT so introduce it
 	irc.SetupFeatureDetect()
@@ -28,13 +84,9 @@ func (irc *Connection) SetupNickTrack() {
 	// will typically receive this on channel joins and when NAMES is
 	// called via GetNicksOnChan
 	irc.AddCallback("353", func(e *Event) {
-		// get chan
-		channelName := e.Arguments[2]
 
 		// check if chan exists in map, if not make one
-		if _, ok := irc.Channels[channelName]; !ok {
-			irc.Channels[channelName] = Channel{Users: make(map[string]User)}
-		}
+		channel := irc.getOrCreateChannel(e.Arguments[2])
 
 		for _, modenick := range strings.Split(e.Message(), " ") {
 			u := User{}
@@ -49,60 +101,74 @@ func (irc *Connection) SetupNickTrack() {
 			if idx > 0 {
 				u.Mode = "+"
 				for _, mc := range modenick[0:idx] {
-					u.Mode += string(irc.KnownFeatures.PrefixModesDisplay[mc])
+					u.Mode += string(irc.PrefixModes().Display[mc])
 				}
 			}
 
-			irc.Channels[channelName].Users[modenick[idx:]] = u
+			channel.Lock()
+			channel.Users[modenick[idx:]] = u
+			channel.Unlock()
 		}
 	})
 
+	// FIXME: I don't handle multiple modes in the same Event!!!
 	irc.AddCallback("MODE", func(e *Event) {
-		channelName := e.Arguments[0]
 		if len(e.Arguments) == 3 { // 3 == for channel 2 == for user on server
-			if _, ok := irc.Channels[channelName]; ok != true {
-				irc.Channels[channelName] = Channel{Users: make(map[string]User)}
-			}
-			if _, ok := irc.Channels[channelName].Users[e.Arguments[2]]; ok != true {
-				irc.Channels[channelName].Users[e.Arguments[2]] = User{Mode: e.Arguments[1]}
+			channel := irc.getOrCreateChannel(e.Arguments[0])
+			channel.Lock()
+			defer channel.Unlock()
+
+			if _, ok := channel.Users[e.Arguments[2]]; ok != true {
+				channel.Users[e.Arguments[2]] = User{Mode: e.Arguments[1]}
 			} else {
-				u := irc.Channels[channelName].Users[e.Arguments[2]]
+				u := channel.Users[e.Arguments[2]]
 				u.Mode = e.Arguments[1]
-				irc.Channels[channelName].Users[e.Arguments[2]] = u
+				channel.Users[e.Arguments[2]] = u
 			}
 		}
 	})
 
-	//Really hacky since the message from the server does not include the channel
+	// IRC doesn't report Channels when a nick is changed, so we have to figure this out
+	// based on prior acquired tracking information
+	// Maybe a User should keep a reference to all the channels they're in?
 	irc.AddCallback("NICK", func(e *Event) {
 		if len(e.Arguments) == 1 { // Sanity check
-			for k, _ := range irc.Channels {
-				if _, ok := irc.Channels[k].Users[e.Nick]; ok {
-					u := irc.Channels[k].Users[e.Nick]
+			irc.channelsMutex.Lock()
+			defer irc.channelsMutex.Unlock()
+			for _, ch := range irc.Channels {
+				ch.Lock()
+				if _, ok := ch.Users[e.Nick]; ok {
+					u := ch.Users[e.Nick]
 					u.Host = e.Host
-					irc.Channels[k].Users[e.Arguments[0]] = u //New nick
-					delete(irc.Channels[k].Users, e.Nick)     //Delete old
+					ch.Users[e.Arguments[0]] = u
+					delete(ch.Users, e.Nick)
 				}
+				ch.Unlock()
 			}
 		}
 	})
 
 	irc.AddCallback("JOIN", func(e *Event) {
-		channelName := e.Arguments[0]
-		if _, ok := irc.Channels[channelName]; ok != true {
-			irc.Channels[channelName] = Channel{Users: make(map[string]User)}
-		}
-		irc.Channels[channelName].Users[e.Nick] = User{Host: e.Source}
+		channel := irc.getOrCreateChannel(e.Arguments[0])
+		channel.Lock()
+		defer channel.Unlock()
+		channel.Users[e.Nick] = User{Host: e.Source}
 	})
 
 	irc.AddCallback("PART", func(e *Event) {
-		channelName := e.Arguments[0]
-		delete(irc.Channels[channelName].Users, e.Nick)
+		channel := irc.getOrCreateChannel(e.Arguments[0])
+		channel.Lock()
+		defer channel.Unlock()
+		delete(channel.Users, e.Nick)
 	})
 
 	irc.AddCallback("QUIT", func(e *Event) {
-		for k, _ := range irc.Channels {
-			delete(irc.Channels[k].Users, e.Nick)
+		irc.channelsMutex.Lock()
+		defer irc.channelsMutex.Unlock()
+		for _, ch := range irc.Channels {
+			ch.Lock()
+			delete(ch.Users, e.Nick)
+			ch.Unlock()
 		}
 	})
 }

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -60,7 +60,10 @@ type Connection struct {
 	stopped bool
 	quit    bool
 
-	Channels map[string]Channel
+	Channels      map[string]Channel
+	KnownFeatures KnownFeatures
+	Features      *Features
+	featuresMutex sync.Mutex
 }
 
 // A struct to represent an event.

--- a/irc_struct.go
+++ b/irc_struct.go
@@ -60,10 +60,10 @@ type Connection struct {
 	stopped bool
 	quit    bool
 
-	Channels      map[string]Channel
-	KnownFeatures KnownFeatures
-	Features      *Features
-	featuresMutex sync.Mutex
+	// leaving exposed for now, will be unexported in the future!
+	channelsMutex sync.Mutex
+	Channels      map[string]*Channel
+	features      *Features
 }
 
 // A struct to represent an event.


### PR DESCRIPTION
This commit adds support for using RPL_005 (ISUPPORT) reported feature details of a server. The main point is to enable client code both internal and external to stop using hard coded values for things such as prefix modes. This uses the defaults (static and dynamic) according to ircdocs.horse and replaces them when the server's ISUPPORT indicates a difference.

This adds several methods to the `Connection` implementation for getting features and iterating over them. It also exposes a method for the 2 features we currently parse out - `PrefixModes()`, `NickLength()`. `irc_isupport.go` is coded to be defensive against raising panics regarding concurrent reads and writes to a map.

Along with the new feature comes fixes for `irc_nicktrack.go`. Primarily it makes it use the ISUPPORT features to detect nick modes in RPL_353 (RPL_NAMESREPLY). Additionally whilst leaving the old method of accessing the data nick tracking surfaces it provides a new set of methods over the `Connection` for accessing the same data. The new methods are similar in line with the ones from `irc_isupport.go` in that it provides ways for getting the channels, iterating over the channels, getting users from a channel, and iterating over the users in a channel. The new set of methods are similar in vein to those in `irc_isupport.go` and are coded to be defensive against raising panics regarding concurrent reads and writes. The old way of accessing such data is left in place at this time to keep from breaking other applications that may rely on this project (those should be updated as soon as they can). 

No new fields are exported on the `Connection`. This also means that when using the old method of accessing channel data there is no way to protect against the aforementioned panic. One should use the new set of methods instead of trying to get around this.

This will fix #1 and fix #2.