### PR TITLE
Ordered execution fix

### DIFF
--- a/irc_struct.go
+++ b/irc_struct.go
@@ -64,9 +64,9 @@ type Connection struct {
 	quit    bool
 
 	// leaving exposed for now, will be unexported in the future!
-	channelsMutex sync.Mutex
-	Channels      map[string]*Channel
-	features      *Features
+	stateLock sync.RWMutex
+	Channels  map[string]*Channel
+	features  *Features
 }
 
 // A struct to represent an event.


### PR DESCRIPTION
We need a way to call callbacks after our callbacks have completed. This accomplishes that by creating new callbacks for each Event Code we handle prefixed with "ST" (for state tracking). 

This won't make any difference for accesses against a Channel or User wherein it's not being done from within an "ST*" callback (they are stuck with whatever the state was at point of call). This does help in go-discord-irc and after testing repeatedly with the "STNICK" handler I cannot seem to invoke the issues I keep noting over there (dropped nick changes due to state not reflecting expectations due to parallel execution of state related callbacks and go-discord-irc callbacks).

When/if this is merged we'll be able to change things in go-discord-irc to rely on "ST*" for message relaying.