### PR TITLE
Fix a logic error in STQUIT handling

### DIFF
--- a/irc_nicktrack.go
+++ b/irc_nicktrack.go
@@ -168,12 +168,13 @@ func (irc *Connection) SetupNickTrack() {
 	})
 
 	irc.AddCallback("QUIT", func(e *Event) {
+		// QUIT callbacks need to run *before* we clear the state!
+		e.Code = "STQUIT"
+		irc.RunCallbacks(e)
 		irc.stateLock.Lock()
 		for _, ch := range irc.Channels {
 			delete(ch.Users, e.Nick)
 		}
 		irc.stateLock.Unlock()
-		e.Code = "STQUIT"
-		irc.RunCallbacks(e)
 	})
 }


### PR DESCRIPTION
We need to call all callbacks *before* we modify the state, this fixes that.

The issue is that the callbacks need to know the state prior to quitting, such as which channels a user is on. Prior we fired STQUIT after having cleared state. Now we fire it before which means all STQUIT consumers should see the current state right before it is cleared.